### PR TITLE
Add master arm type system for apc

### DIFF
--- a/server/configs/building_features.hpp
+++ b/server/configs/building_features.hpp
@@ -69,6 +69,8 @@ class CfgBuildingFeatures
 		onBuildingPlaced = "para_s_fnc_bf_veh_spawn_on_building_placed";
 		onBuildingObjectsChanged = "para_s_fnc_bf_veh_spawn_on_building_objects_changed";
 		onBuildingDeleted = "para_s_fnc_bf_veh_spawn_on_building_deleted";
+		onBuildingFunctional = "para_s_fnc_bf_veh_spawn_on_functional";
+		onBuildingNonFunctional = "para_s_fnc_bf_veh_spawn_on_nonfunctional";
 	};
 
 	class wreck_recovery

--- a/server/functions.hpp
+++ b/server/functions.hpp
@@ -123,6 +123,8 @@ class para_s
 		class bf_veh_spawn_create_vehicle_rehandler {};
 		class bf_veh_spawn_on_building_objects_changed {};
 		class bf_veh_spawn_on_building_placed {};
+		class bf_veh_spawn_on_functional {};
+		class bf_veh_spawn_on_nonfunctional {};
 	};
 
 	class building_features_wreck_recovery

--- a/server/functions/basebuilding/fn_building_create.sqf
+++ b/server/functions/basebuilding/fn_building_create.sqf
@@ -90,9 +90,11 @@ _building setVariable ["para_g_objects", _objects, true];
 [_building, _buildProgress, false] call para_s_fnc_building_add_build_progress;
 
 //Block master arm from using buildings as a supply point.
-_building setVariable ["vn_master_arm_supplyAmmo", false, true];
-_building setVariable ["vn_master_arm_supplyFuel", false, true];
-_building setVariable ["vn_master_arm_supplyRepair", false, true];
+{
+	_x setVariable ["vn_master_arm_supplyAmmo", false, true];
+	_x setVariable ["vn_master_arm_supplyFuel", false, true];
+	_x setVariable ["vn_master_arm_supplyRepair", false, true];
+}forEach _objects;
 
 para_l_buildings pushBack _building;
 

--- a/server/functions/basebuilding/fn_building_create.sqf
+++ b/server/functions/basebuilding/fn_building_create.sqf
@@ -89,6 +89,11 @@ _building setVariable ["para_g_objects", _objects, true];
 //Do NOT do an object update, as we've instantiated everything correctly above.
 [_building, _buildProgress, false] call para_s_fnc_building_add_build_progress;
 
+//Block master arm from using buildings as a supply point.
+_building setVariable ["vn_master_arm_supplyAmmo", false, true];
+_building setVariable ["vn_master_arm_supplyFuel", false, true];
+_building setVariable ["vn_master_arm_supplyRepair", false, true];
+
 para_l_buildings pushBack _building;
 
 [_building, "onBuildingPlaced", [_building]] call para_g_fnc_building_fire_feature_event;

--- a/server/functions/building_features/vehicle_spawning/fn_bf_veh_spawn_on_functional.sqf
+++ b/server/functions/building_features/vehicle_spawning/fn_bf_veh_spawn_on_functional.sqf
@@ -1,0 +1,22 @@
+/*
+    File: fn_bf_veh_spawn_on_functional.sqf
+    Author:  Savage Game Design
+    Public: No
+
+    Description:
+		Called when a vehicle spawn starts functioning. Allows it to operate as a master arm station. Does not provide vehicle supplies.
+
+    Parameter(s):
+		_building - Building that became functional [OBJECT]
+
+    Returns:
+        Function reached the end [BOOL]
+
+    Example(s):
+        See building features config
+*/
+params ["_building"];
+
+private _buildingObject = (_building getVariable "para_g_objects") select 0;
+
+vn_fnc_masterarm_action_objects pushBackUnique _buildingObject;

--- a/server/functions/building_features/vehicle_spawning/fn_bf_veh_spawn_on_nonfunctional.sqf
+++ b/server/functions/building_features/vehicle_spawning/fn_bf_veh_spawn_on_nonfunctional.sqf
@@ -1,0 +1,22 @@
+/*
+	File: fn_bf_veh_spawn_on_nonfunctional.sqf
+	Author:  Savage Game Design
+	Public: No
+
+	Description:
+  Called when a vehicle spawn stops functioning. Removes the ability to operate as a master arm station.
+
+	Parameter(s):
+  _building - Building that became nonfunctional [OBJECT]
+
+	Returns:
+		Function reached the end [BOOL]
+
+	Example(s):
+		See building features config
+*/
+params ["_building"];
+
+private _buildingObject = _building getVariable "para_g_objects";
+
+vn_fnc_masterarm_action_objects deleteAt (vn_fnc_masterarm_action_objects find _buildingObject);


### PR DESCRIPTION
Currently not able to supply from this master arm menu except for certain edge cases. Any cases where resupply is possible will be fixed with the next DLC update. The only exception to this is that by bringing the appropriate supply vehicles forward you will be able to use them in conjunction with this master arm window. This is an intended feature and will not be removed.

To be merged with https://github.com/Savage-Game-Design/Mike-Force/pull/149. Currently blocked by https://github.com/Savage-Game-Design/Mike-Force/pull/148.