### PR TITLE
If last man in an AO is wounded, all AI despawn

### DIFF
--- a/server/functions/ai_objectives/fn_ai_obj_job.sqf
+++ b/server/functions/ai_objectives/fn_ai_obj_job.sqf
@@ -13,7 +13,7 @@
 	Example(s): none
 */
 
-private _allPlayers = allUnits select {side _x == west && !(vehicle _x isKindOf "Plane") && !(speed vehicle _x > 300)};
+private _allPlayers = allUnits select {isPlayer _x && {!(_x isKindOf "HeadlessClient_F")} && !(vehicle _x isKindOf "Plane") && !(speed vehicle _x > 300)};
 
 //Groups of AI that are no longer in use by the system.
 //We can reuse these for other objectives later.


### PR DESCRIPTION
Check for players instead of west units. Wounded players are civs, hence the despawns. Also future proofing if other factions get used.