### PR TITLE
WheelMenu: Fixup new submenu entries clashing with old menu entries

### DIFF
--- a/client/functions/ui/wheel_menu/fn_wheel_menu_open.sqf
+++ b/client/functions/ui/wheel_menu/fn_wheel_menu_open.sqf
@@ -96,7 +96,7 @@ if (!isNull _oldDisplay) then {
 [_wheelMenuEntries, _object] spawn {
 	params ["_wheelMenuEntries", "_object"];
 	// Try to stop wheel menus clashing with each other if close/open overlaps for some reason
-	uiSleep 0;
+	uiSleep 0.02;
 
 	// close menu on repeated press
 	private _EH_closeWM = {


### PR DESCRIPTION
`uiSleep` for longer than 0 seconds, otherwise old entries from the previous menu display are not removed in time (due to prior `closeDisplay` call needing to wait for next simulation cycle...?).

Causes clashes where the scout/earplugs actions are overlapping on the wheel menu in strange ways

example

![20240406140001_1](https://github.com/Savage-Game-Design/Paradigm/assets/11841332/8c91fc73-f9e1-4f15-ab81-2ca92fc7bcbb)
