### PR TITLE
Harass: Bugfix: double harassment of FOBs.

### DIFF
--- a/server/functions/harass/fn_harass_create_squads.sqf
+++ b/server/functions/harass/fn_harass_create_squads.sqf
@@ -66,9 +66,6 @@
 		_x setVariable ["harass_level", _enemyRatioComponent];
 	} forEach _harassablePlayers;
 
-	//Find players that aren't harassed enough.
-	private _friendlyPlayersToHarass = _harassablePlayers select {_x getVariable "harass_level" < 1};
-
 	//Keep occupied FOBs harassed
 	private _playersToRemove = [];
 	{
@@ -91,6 +88,9 @@
 	} forEach para_g_bases;
 
 	private _harassablePlayers = _harassablePlayers - _playersToRemove;
+
+	//Find players that aren't harassed enough.
+	private _friendlyPlayersToHarass = _harassablePlayers select {_x getVariable "harass_level" < 1};
 
 	private _lastPlayersToHarassLength = -1;
 


### PR DESCRIPTION
See here for explanation: https://github.com/Savage-Game-Design/Paradigm/issues/5

---

A FOB can have half the AI of a 'capture' phase AO assigned to harass it because the harass subsystem assigns multiple AI objectives to bother players at the FOB

- 1x 'attack' AI objective -- "send a bunch of AI to keep the FOB occupied" AI objective
- Nx 'pursue' AI objectives -- "track these players through the jungle to keep them under pressure" objectives

It doesn't make sense to 'pursue' players at a FOB when they are mostly stationary, and it's probably better tohave those AI tasked somewhere else (tracking players out in the field or on other 'defend'/ambush' objectives).

There's a risk of FOBs feeling under-harrased after the change, but we can tweak the harassment period and/or the attack intensity here if desired: https://github.com/Savage-Game-Design/Paradigm/blob/development/server/functions/harass/fn_harass_create_squads.sqf#L80-L89 