### PR TITLE
Hotfix for sandbag walls hovering when built by players.

### DIFF
--- a/server/functions/basebuilding/fn_building_create.sqf
+++ b/server/functions/basebuilding/fn_building_create.sqf
@@ -74,10 +74,12 @@ private _objects = _spawnInfo apply
 	private _newObject = createVehicle [_objectClass, ASLtoAGL _pos, [], 0, 'CAN_COLLIDE'];
 	_newObject setDir _dir;
 
-	// HACKFIX: bugfix for Land_vn_bagfence_long_f_part0 model having no autocentering.
+	// @dijksterhuis: GitHub/Paradigm/#8: https://github.com/Savage-Game-Design/Paradigm/issues/8
+	// HACK: bugfix for Land_vn_bagfence_long_f_part0 model having no autocentering.
 	// Land_vn_bagfence_long_f does have autocentering, which means the real part spawns
-	// in higher than the ghost part. `0.419312` was measured manually, so this may not
-	// be an exact fix.
+	// in higher than the ghost part. `0.419312` was measured manually, so this fix will
+	// only apply to Land_vn_bagfence_long_f. No other autocentering issues have been spotted
+	// with other buildables, so it should be fine (at least for now).
 	if (_objectClass isEqualTo "Land_vn_bagfence_long_f") then {_pos = _pos vectorAdd [0, 0, -0.419312]};
 
 	//Need to reset position as the spawned-in position will be inaccurate, and is broken by the rotation anyway.

--- a/server/functions/basebuilding/fn_building_create.sqf
+++ b/server/functions/basebuilding/fn_building_create.sqf
@@ -73,6 +73,13 @@ private _objects = _spawnInfo apply
 	//This position is always going to be a bit inaccurate, as we don't have model's center offset until it's spawned in.
 	private _newObject = createVehicle [_objectClass, ASLtoAGL _pos, [], 0, 'CAN_COLLIDE'];
 	_newObject setDir _dir;
+
+	// HACKFIX: bugfix for Land_vn_bagfence_long_f_part0 model having no autocentering.
+	// Land_vn_bagfence_long_f does have autocentering, which means the real part spawns
+	// in higher than the ghost part. `0.419312` was measured manually, so this may not
+	// be an exact fix.
+	if (_objectClass isEqualTo "Land_vn_bagfence_long_f") then {_pos = _pos vectorAdd [0, 0, -0.419312]};
+
 	//Need to reset position as the spawned-in position will be inaccurate, and is broken by the rotation anyway.
 	_newObject setPosWorld _pos;
 	_newObject setVariable ["para_g_building", _building, true];


### PR DESCRIPTION
Hotfix for #8 -- manually lowers sandbag wall z co-ord. Have tested like 20 other buildables and nothing seemed affected. So hacky fix for now unless it becomes a wider issue.